### PR TITLE
Performace optimization

### DIFF
--- a/include/boost/winasio/http/convert.hpp
+++ b/include/boost/winasio/http/convert.hpp
@@ -115,6 +115,7 @@ private:
   net::dynamic_vector_buffer<CHAR, std::allocator<CHAR>> dynamic_body_buff_;
 };
 
+// Do not use this in prod since printing is expensive.
 inline std::ostream &operator<<(std::ostream &os, simple_request const &m) {
 
   PHTTP_REQUEST req = m.get_request();
@@ -140,11 +141,11 @@ public:
       : resp_(), data_chunks_(), reason_(), body_(), known_headers_(),
         unknown_headers_() {}
 
-  inline void set_reason(const std::string &reason) { reason_ = reason; }
+  inline void set_reason(std::string reason) { reason_ = std::move(reason); }
 
-  inline void set_content_type(const std::string &content_type) {
+  inline void set_content_type(std::string content_type) {
     // content_type_ = content_type;
-    this->add_known_header(HttpHeaderContentType, content_type);
+    this->add_known_header(HttpHeaderContentType, std::move(content_type));
   }
 
   inline void set_status_code(USHORT status_code) {
@@ -152,18 +153,18 @@ public:
   }
 
   // use std::move to move body into response if needed.
-  inline void set_body(std::string body) { body_ = body; }
+  inline void set_body(std::string body) { body_ = std::move(body); }
 
   inline void add_known_header(HTTP_HEADER_ID id, std::string data) {
-    this->known_headers_[id] = data;
+    this->known_headers_[id] = std::move(data);
   }
 
   inline void add_unknown_header(std::string name, std::string val) {
-    this->unknown_headers_[name] = val;
+    this->unknown_headers_[std::move(name)] = std::move(val);
   }
 
   inline void add_trailer(std::string name, std::string val) {
-    this->trailers_[name] = val;
+    this->trailers_[std::move(name)] = std::move(val);
   }
 
   inline PHTTP_RESPONSE get_response() {

--- a/tests/http/beast_client.hpp
+++ b/tests/http/beast_client.hpp
@@ -23,6 +23,7 @@ public:
   inline void set_body(std::string body) { body_ = body; }
 
   // private:
+  http::verb verb_ = http::verb::get;
   std::map<std::string, std::string> headers_;
   std::string body_;
 };
@@ -51,10 +52,12 @@ inline boost::system::error_code make_test_request(test_request const &request,
   // Make the connection on the IP address we get from a lookup
   stream.connect(results);
 
-  // Set up an HTTP GET request message
-  http::request<http::string_body> req{http::verb::get, "/winhttpapitest", 11};
+  // Set up an HTTP request message
+  http::request<http::string_body> req{request.verb_, "/winhttpapitest", 11};
   req.set(http::field::host, "localhost");
   req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+  req.body() = request.body_;
+  req.prepare_payload();
 
   // Set custom header
   for (auto &kv : request.headers_) {

--- a/tests/http/http_server_test.cpp
+++ b/tests/http/http_server_test.cpp
@@ -88,6 +88,8 @@ void http_server_test_helper() {
 
   test_request req;
   test_response resp;
+  req.verb_ = http::verb::post;
+  req.set_body("myRequestBody");
   req.add_header("myheader", "myval");
   // make client call
   ec = make_test_request(req, resp);


### PR DESCRIPTION
Use move semantics for request_str.
Use efficient encoding to buffer for protobuf parsing.

Also includes #10 
But note that grpc repo cannot directly use the body hint as yet.
Body len hint is 128 for now.


